### PR TITLE
Color by branch

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,9 +110,15 @@ document.addEventListener('DOMContentLoaded', () => {
         vectorSource2 = new ol.source.Vector()
         vectorLayer2 = new ol.layer.Vector({
           source: vectorSource2,
-          style: new ol.style.Style({
-            stroke: new ol.style.Stroke({ color: '#ff0000', width: 3 }),
-          }),
+          style: (feature) => {
+            const color = feature.get('color') || '#ff0000' // fallback si pas défini
+            return new ol.style.Style({
+              stroke: new ol.style.Stroke({
+                color: color,
+                width: 3,
+              }),
+            })
+          },
         })
 
         popupCloser.onclick = () => {
@@ -161,7 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
             let content = '<strong>Propriétés</strong><br><hr>'
             const properties = feature.getProperties()
             for (const key in properties) {
-              if (key !== 'geometry') {
+              if (key !== 'geometry' && key !== 'color') {
                 content += `<strong>${key}:</strong> ${properties[key]}<br>`
               }
             }


### PR DESCRIPTION
Alors, cette PR possede ~~deux~~ *une* chose~~s~~. 

~~D'une part, j'ai ajouté "bun" aux dev deps pour ne pas présupposé que bun soit installé sur le système.~~

D'autre part, j'ai voulu faire en sorte qu'il soit possible d'avoir la couleur présente dans le geojson : A terme je souhaiterais pouvoir mettre les branches du chapeau, car il semble y en avoir beaucoup. Je me dis qu'avoir le tracé principal en rouge, et les branches en orange me semble quelque chose de clair pour s'y retrouver...

Pour ça, ça me semble plus logique de mettre la couleur dans le geojson et de laisser le gdoc décider de la couleur...

Exemple de geojson:
```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            -0.771592128222679,
            45.0674999024531
          ],
(...)
          [
            -36.5502835344726,
            90
          ]
        ]
      },
      "properties": {
        "nom": "Branche principale du chapeau vers le pole Nord",
        "color": "#ffcc00"
      }
    },
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            -36.5504593157226,
            -90
          ],
(...)
          [
            -36.5502835344726,
            -83.2724456685572
          ]
        ]
      },
      "properties": {
        "nom": "Branche principale du chapeau depuis le pole Sud",
        "color": "#cc00ff"
      }
    },
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            -0.77141634697268,
            45.0656376281937
          ],
(...)

          [
            -0.183076503222668,
            40.4843258388849
          ]
        ]
      },
      "properties": {
        "nom": "Banche principale de la fin du chapeau",
        "color": "#ccffcc"
      }
    }
  ]
}
```

Exemple de rendu:
<img width="351" height="1291" alt="image" src="https://github.com/user-attachments/assets/3366eb9f-606a-4833-bbfc-5c42f663253a" /> 
<img width="542" height="1291" alt="image" src="https://github.com/user-attachments/assets/37960193-d8bb-4d07-9ddd-022f0a9e87ff" />


Note: La couleur des adface est volontairement altéré sur mon site de test pour que je ne le confonde pas avec le adface "de prod".

Url d'un geojson: https://gist.githubusercontent.com/gisstest/b5c68849c31452e3f999c37be9761065/raw (note: il est actuellement comme dans l'exemple, mais sera peut etre différent dans le futur)
Url de mon site de test: https://adface.frondan.jgi.fr/

Enfin, cette PR est rétro compatible avec le gist actuel https://gist.github.com/kernoeb/462dc24f707235bb99cb09333f330de7/raw : Il n'y a ni changement ni régression avec le geojson actuel.

Je compte dans un second temps modifier le gdoc et le script associé pour:
- Mettre potentiellement un nom sur  chaque branche dans le gdoc
- Avoir un onglet dédié aux branches (et donc mettre une couleur orange pour cet onglet dans le script)
- Gérer les portals comme un changement de LineString (mais la meme branche, c'est à dire que le nom sera toujours celui de la branche précédente)